### PR TITLE
Delete `internal_bit.zig`, replace `bitCeil` with `std.math.ceilPowerOfTwo`

### DIFF
--- a/src/internal_bit.zig
+++ b/src/internal_bit.zig
@@ -1,7 +1,0 @@
-pub fn bitCeil(n: usize) usize {
-    var x: usize = 1;
-    while (x < n) {
-        x *= 2;
-    }
-    return x;
-}

--- a/src/lazysegtree.zig
+++ b/src/lazysegtree.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
+const math = std.math;
 const Allocator = std.mem.Allocator;
-const internal = @import("internal_bit.zig");
 const assert = std.debug.assert;
 
 pub fn LazySegtree(
@@ -23,7 +23,7 @@ pub fn LazySegtree(
         allocator: Allocator,
 
         pub fn init(allocator: Allocator, n: usize) !Self {
-            const size = internal.bitCeil(n);
+            const size = try math.ceilPowerOfTwo(usize, n);
             const log = @ctz(size);
             const self = Self{
                 .n = n,
@@ -39,7 +39,7 @@ pub fn LazySegtree(
         }
         pub fn initFromSlice(allocator: Allocator, v: []const S) !Self {
             const n = v.len;
-            const size = internal.bitCeil(n);
+            const size = try math.ceilPowerOfTwo(usize, n);
             const log = @ctz(size);
             var self = Self{
                 .n = n,
@@ -376,7 +376,7 @@ const tests = struct {
             return @max(x, y);
         }
         fn e() S {
-            return std.math.minInt(S);
+            return math.minInt(S);
         }
         fn mapping(f: F, x: S) S {
             return f + x;

--- a/src/segtree.zig
+++ b/src/segtree.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const internal = @import("internal_bit.zig");
+const math = std.math;
 const Allocator = std.mem.Allocator;
 const assert = std.debug.assert;
 
@@ -14,7 +14,7 @@ pub fn Segtree(comptime S: type, comptime op: fn (S, S) S, comptime e: fn () S) 
         allocator: Allocator,
 
         pub fn init(allocator: Allocator, n: usize) !Self {
-            const size = internal.bitCeil(n);
+            const size = try math.ceilPowerOfTwo(usize, n);
             const log = @ctz(size);
             const self = Self{
                 .n = n,
@@ -28,7 +28,7 @@ pub fn Segtree(comptime S: type, comptime op: fn (S, S) S, comptime e: fn () S) 
         }
         pub fn initFromSlice(allocator: Allocator, v: []const S) !Self {
             const n = v.len;
-            const size = internal.bitCeil(n);
+            const size = try math.ceilPowerOfTwo(usize, n);
             const log = @ctz(size);
             var self = Self{
                 .n = n,

--- a/src/segtree.zig
+++ b/src/segtree.zig
@@ -251,7 +251,7 @@ const monoid = struct {
                 return @max(x, y);
             }
             fn e() S {
-                return std.math.minInt(S);
+                return math.minInt(S);
             }
         };
     }


### PR DESCRIPTION
Since `std.math.ceilPowerOfTwo` provides the same functionality as `internal_bit.bitCeil`, `internal_bit.zig` is no longer needed.