### PR TITLE
Update for Zig 0.15.1

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .ac_library,
     .version = "0.3.0",
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.1",
     .fingerprint = 0x8ab1cf135fb49dc,
     .paths = .{
         "src",

--- a/src/internal_csr.zig
+++ b/src/internal_csr.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
+const ArrayList = std.ArrayList;
 
 pub fn Csr(comptime E: type) type {
     return struct {
@@ -9,15 +10,15 @@ pub fn Csr(comptime E: type) type {
         elist: []E,
         allocator: Allocator,
 
-        pub fn init(allocator: Allocator, n: usize, edges: std.ArrayList(struct { usize, E }), initialValue: E) !Self {
+        pub fn init(allocator: Allocator, n: usize, edges: []struct { usize, E }, initialValue: E) !Self {
             const self = Self{
                 .start = try allocator.alloc(usize, n + 1),
-                .elist = try allocator.alloc(E, edges.items.len),
+                .elist = try allocator.alloc(E, edges.len),
                 .allocator = allocator,
             };
             @memset(self.start, 0);
             @memset(self.elist, initialValue);
-            for (edges.items) |e| {
+            for (edges) |e| {
                 self.start[e.@"0" + 1] += 1;
             }
             for (1..n + 1) |i| {
@@ -26,7 +27,7 @@ pub fn Csr(comptime E: type) type {
             var counter = try allocator.alloc(usize, n + 1);
             defer allocator.free(counter);
             @memcpy(counter, self.start);
-            for (edges.items) |e| {
+            for (edges) |e| {
                 self.elist[counter[e.@"0"]] = e.@"1";
                 counter[e.@"0"] += 1;
             }

--- a/src/internal_queue.zig
+++ b/src/internal_queue.zig
@@ -14,7 +14,7 @@ pub fn SimpleQueue(comptime T: type) type {
         pub fn init(allocator: Allocator) Self {
             return Self{
                 .allocator = allocator,
-                .payload = .{},
+                .payload = .empty,
                 .pos = 0,
             };
         }

--- a/src/internal_queue.zig
+++ b/src/internal_queue.zig
@@ -14,7 +14,7 @@ pub fn SimpleQueue(comptime T: type) type {
         pub fn init(allocator: Allocator) Self {
             return Self{
                 .allocator = allocator,
-                .payload = .init(allocator),
+                .payload = .{},
                 .pos = 0,
             };
         }
@@ -28,7 +28,7 @@ pub fn SimpleQueue(comptime T: type) type {
         }
 
         pub fn deinit(self: *Self) void {
-            self.payload.deinit();
+            self.payload.deinit(self.allocator);
         }
 
         pub fn size(self: Self) usize {
@@ -40,7 +40,7 @@ pub fn SimpleQueue(comptime T: type) type {
         }
 
         pub fn push(self: *Self, t: T) Allocator.Error!void {
-            return self.payload.append(t);
+            return self.payload.append(self.allocator, t);
         }
 
         pub fn pushAssumeCapacity(self: *Self, t: T) void {
@@ -55,7 +55,7 @@ pub fn SimpleQueue(comptime T: type) type {
         }
 
         pub fn clearAndFree(self: *Self) void {
-            self.payload.clearAndFree();
+            self.payload.clearAndFree(self.allocator);
             self.pos = 0;
         }
 

--- a/src/internal_scc.zig
+++ b/src/internal_scc.zig
@@ -42,7 +42,7 @@ pub fn addEdge(self: *SccGraph, from: usize, to: usize) !void {
 }
 pub fn sccIds(self: SccGraph) !struct { usize, []usize } {
     var env = Env{
-        .g = try .init(self.allocator, self.n, self.edges, Edge{ .to = 0 }),
+        .g = try .init(self.allocator, self.n, self.edges.items, Edge{ .to = 0 }),
         .now_ord = 0,
         .group_num = 0,
         .visited = try .initCapacity(self.allocator, self.n),
@@ -83,7 +83,7 @@ pub fn scc(self: SccGraph) !Groups {
     for (0..self.n) |i| {
         group_index[i] = ids[i];
     }
-    return try Groups.init(self.allocator, group_num, group_index);
+    return try .init(self.allocator, group_num, group_index);
 }
 fn dfs(allocator: Allocator, v: usize, n: usize, env: *Env) !void {
     env.low[v] = env.now_ord;

--- a/src/internal_scc.zig
+++ b/src/internal_scc.zig
@@ -26,7 +26,7 @@ allocator: Allocator,
 pub fn init(allocator: Allocator, n: usize) SccGraph {
     const self = SccGraph{
         .n = n,
-        .edges = .{},
+        .edges = .empty,
         .allocator = allocator,
     };
     return self;

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -17,8 +17,20 @@ pub const Modint998244353 = @import("modint.zig").Modint998244353;
 pub const DynamicModint = @import("modint.zig").DynamicModint;
 pub const Modint = @import("modint.zig").Modint;
 
-pub usingnamespace @import("math.zig");
-pub usingnamespace @import("string.zig");
+pub const math = @import("math.zig");
+pub const powMod = math.powMod;
+pub const invMod = math.invMod;
+pub const crt = math.crt;
+pub const floorSum = math.floorSum;
+
+pub const string = @import("string.zig");
+pub const suffixArrayManual = string.suffixArrayManual;
+pub const suffixArrayArbitrary = string.suffixArrayArbitrary;
+pub const suffixArray = string.suffixArray;
+pub const lcpArrayArbitrary = string.lcpArrayArbitrary;
+pub const lcpArray = string.lcpArray;
+pub const zAlgorithmArbitrary = string.zAlgorithmArbitrary;
+pub const zAlgorithm = string.zAlgorithm;
 
 test {
     std.testing.refAllDecls(@This());

--- a/src/mincostflow.zig
+++ b/src/mincostflow.zig
@@ -71,7 +71,7 @@ pub fn McfGraph(comptime Cap: type, comptime Cost: type) type {
         pub fn init(allocator: Allocator, n: usize) Self {
             return Self{
                 .allocator = allocator,
-                .edges = .{},
+                .edges = .empty,
                 .n = n,
             };
         }
@@ -315,7 +315,7 @@ pub fn McfGraph(comptime Cap: type, comptime Cost: type) type {
                 var flow_current: Cap = 0;
                 var cost_current: Cost = 0;
                 var prev_cost_per_flow: Cost = -1;
-                var result: ArrayList(CapCostPair) = .{};
+                var result: ArrayList(CapCostPair) = .empty;
                 try result.append(self.allocator, CapCostPair{ 0, 0 });
                 while (flow_current < flow_limit) {
                     if (!try self.refineDual(s, t, g, dual_dist, vis, prev_e)) {
@@ -390,7 +390,7 @@ pub fn McfGraph(comptime Cap: type, comptime Cost: type) type {
                     return math.order(a.key, b.key);
                 }
             };
-            var que_min: ArrayList(usize) = .{};
+            var que_min: ArrayList(usize) = .empty;
             defer que_min.deinit(self.allocator);
             var que = std.PriorityQueue(Q, void, Q.lessThan).init(allocator, {});
             defer que.deinit();

--- a/src/mincostflow.zig
+++ b/src/mincostflow.zig
@@ -71,14 +71,14 @@ pub fn McfGraph(comptime Cap: type, comptime Cost: type) type {
         pub fn init(allocator: Allocator, n: usize) Self {
             return Self{
                 .allocator = allocator,
-                .edges = .init(allocator),
+                .edges = .{},
                 .n = n,
             };
         }
 
         /// Release all allocated memory.
         pub fn deinit(self: *Self) void {
-            self.edges.deinit();
+            self.edges.deinit(self.allocator);
         }
 
         /// Adds an edge oriented from `from` to `to` with capacity `cap` and cost `cost`.
@@ -105,7 +105,7 @@ pub fn McfGraph(comptime Cap: type, comptime Cost: type) type {
             assert(0 <= cap);
             assert(0 <= cost);
             const m = self.edges.items.len;
-            try self.edges.append(Edge{
+            try self.edges.append(self.allocator, Edge{
                 .from = from,
                 .to = to,
                 .cap = cap,
@@ -264,7 +264,7 @@ pub fn McfGraph(comptime Cap: type, comptime Cost: type) type {
                 defer allocator.free(redge_idx);
 
                 var elist = try ArrayList(struct { usize, InsideEdge }).initCapacity(allocator, 2 * m);
-                defer elist.deinit();
+                defer elist.deinit(self.allocator);
                 for (0..m) |i| {
                     const e = self.edges.items[i];
                     edge_idx[i] = degree[e.from];
@@ -290,7 +290,7 @@ pub fn McfGraph(comptime Cap: type, comptime Cost: type) type {
                         },
                     });
                 }
-                var g = try internal.Csr(InsideEdge).init(allocator, n, elist, .zero);
+                var g = try internal.Csr(InsideEdge).init(allocator, n, elist.items, .zero);
                 for (0..m) |i| {
                     const e = self.edges.items[i];
                     edge_idx[i] += g.start[e.from];
@@ -315,8 +315,8 @@ pub fn McfGraph(comptime Cap: type, comptime Cost: type) type {
                 var flow_current: Cap = 0;
                 var cost_current: Cost = 0;
                 var prev_cost_per_flow: Cost = -1;
-                var result = ArrayList(CapCostPair).init(allocator);
-                try result.append(CapCostPair{ 0, 0 });
+                var result: ArrayList(CapCostPair) = .{};
+                try result.append(self.allocator, CapCostPair{ 0, 0 });
                 while (flow_current < flow_limit) {
                     if (!try self.refineDual(s, t, g, dual_dist, vis, prev_e)) {
                         break;
@@ -338,11 +338,11 @@ pub fn McfGraph(comptime Cap: type, comptime Cost: type) type {
                     if (prev_cost_per_flow == d) {
                         _ = result.pop();
                     }
-                    try result.append(CapCostPair{ flow_current, cost_current });
+                    try result.append(self.allocator, CapCostPair{ flow_current, cost_current });
                     prev_cost_per_flow = d;
                 }
 
-                break :blk try result.toOwnedSlice();
+                break :blk try result.toOwnedSlice(self.allocator);
             };
 
             for (0..m) |i| {
@@ -390,13 +390,13 @@ pub fn McfGraph(comptime Cap: type, comptime Cost: type) type {
                     return math.order(a.key, b.key);
                 }
             };
-            var que_min = ArrayList(usize).init(allocator);
-            defer que_min.deinit();
+            var que_min: ArrayList(usize) = .{};
+            defer que_min.deinit(self.allocator);
             var que = std.PriorityQueue(Q, void, Q.lessThan).init(allocator, {});
             defer que.deinit();
 
             dual[s].@"1" = 0;
-            try que_min.append(s);
+            try que_min.append(self.allocator, s);
             while (que.count() > 0 or que_min.items.len > 0) {
                 const v = que_min.pop() orelse que.remove().to;
                 if (vis[v]) {
@@ -418,7 +418,7 @@ pub fn McfGraph(comptime Cap: type, comptime Cost: type) type {
                         dual[e.to].@"1" = dist_to;
                         prev_e[e.to] = e.rev;
                         if (dist_to == dist_v) {
-                            try que_min.append(e.to);
+                            try que_min.append(self.allocator, e.to);
                         } else {
                             try que.add(Q{ .key = dist_to, .to = e.to });
                         }

--- a/src/string.zig
+++ b/src/string.zig
@@ -2,6 +2,7 @@
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
+const ArrayList = std.ArrayList;
 const assert = std.debug.assert;
 
 fn saNaive(comptime T: type, allocator: Allocator, s: []const T) Allocator.Error![]usize {
@@ -214,8 +215,8 @@ fn saIs(comptime threshold: Threshold, allocator: Allocator, s: []const usize, u
             m += 1;
         }
     }
-    var lms = try std.ArrayList(usize).initCapacity(allocator, m);
-    defer lms.deinit();
+    var lms = try ArrayList(usize).initCapacity(allocator, m);
+    defer lms.deinit(allocator);
     for (1..n) |i| {
         if (!ls[i - 1] and ls[i]) {
             lms.appendAssumeCapacity(i);
@@ -225,8 +226,8 @@ fn saIs(comptime threshold: Threshold, allocator: Allocator, s: []const usize, u
     try induce.f(context, sa, lms.items);
 
     if (m > 0) {
-        var sorted_lms = try std.ArrayList(usize).initCapacity(allocator, m);
-        defer sorted_lms.deinit();
+        var sorted_lms = try ArrayList(usize).initCapacity(allocator, m);
+        defer sorted_lms.deinit(allocator);
         for (sa) |v| {
             if (lms_map[v - 1] != 0) {
                 sorted_lms.appendAssumeCapacity(v - 1);


### PR DESCRIPTION
- [x] dsu.zig
- [x] fenwicktree.zig
- [x] internal_csr.zig
- [x] internal_groups.zig
- [x] internal_math.zig
- [x] internal_queue.zig
- [x] internal_scc.zig
- [x] lazysegtree.zig
- [x] lib.zig
- [x] math.zig
- [x] maxflow.zig
- [x] mincostflow.zig
- [x] modint.zig
- [x] scc.zig
- [x] segtree.zig
- [x] string.zig
- [x] twosat.zig
